### PR TITLE
chore: bump pg_18 to release version

### DIFF
--- a/nix/postgresql/18.nix
+++ b/nix/postgresql/18.nix
@@ -1,4 +1,4 @@
 import ./generic.nix {
-  version = "18beta1";
-  hash = "sha256-C3yD32GVOYqmfb9cAC5/pAgr45Oq6ZqmmSbUg/mOuIU=";
+  version = "18.0";
+  hash = "sha256-DVuQOx5f42G8p6qVB1GZM3c+s0JmsTV8TneA/e5tYHg=";
 }


### PR DESCRIPTION
beta tarballs aren't available any more